### PR TITLE
Fix/curl installer fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ The graphical interface is complete and working with all major features operatio
 **One-command installation:**
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/holstein13/mcp-config-manager/main/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/holstein13/mcp-config-manager/master/install.sh | bash
 ```
 
 The installer will:

--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # MCP Config Manager - Secure One-Click Installer
-# Usage: curl -fsSL https://raw.githubusercontent.com/holstein13/mcp-config-manager/main/install.sh | bash
+# Usage: curl -fsSL https://raw.githubusercontent.com/holstein13/mcp-config-manager/master/install.sh | bash
 
 set -euo pipefail  # Exit on error, undefined vars, pipe failures
 IFS=$'\n\t'        # Set secure Internal Field Separator
@@ -92,7 +92,8 @@ validate_path_input() {
     local path_type="${2:-directory}"
 
     # Check for dangerous characters and patterns
-    if [[ "$input" =~ [;&|<>$\`\\] ]]; then
+    # Using alternation instead of character class for bash 3.x compatibility
+    if [[ "$input" =~ (\;|\&|\||\<|\>|\$|\`|\\) ]]; then
         print_error "Invalid $path_type path: contains shell metacharacters"
         return 1
     fi

--- a/install.sh
+++ b/install.sh
@@ -67,9 +67,11 @@ cleanup_on_failure() {
         print_error "Installation failed with exit code: $exit_code"
 
         # Clean up temp files
-        for temp_file in "${TEMP_FILES[@]}"; do
-            [ -f "$temp_file" ] && rm -f "$temp_file"
-        done
+        if [ ${#TEMP_FILES[@]} -gt 0 ]; then
+            for temp_file in "${TEMP_FILES[@]}"; do
+                [ -f "$temp_file" ] && rm -f "$temp_file"
+            done
+        fi
 
         # Clean up partial installation
         if [ -n "$APP_DIR" ] && [ -d "$APP_DIR" ]; then


### PR DESCRIPTION
Fixes two critical bugs introduced by recent security hardening:

1. Bash 3.x regex syntax error (line 96)
   - Changed character class `[;&|<>$\`\\]` to alternation pattern
   - Semicolon in character class caused "unexpected token" error
   - Affects macOS default bash 3.2

2. TEMP_FILES unbound variable error (line 70)
   - Empty array access fails with `set -u` strict mode
   - Added array length check before iteration
   - Bug exposed by security hardening in PR #17

3. Updated branch references from main to master

Tested on:
- macOS with bash 3.2 (local install)
- GitHub remote install (curl pipe to bash)

Original PR: #18 by @Bafff

🤖 Generated with [Claude Code](https://claude.com/claude-code)